### PR TITLE
electronic_signature: more explit message when error comes from provider

### DIFF
--- a/coopengo_modules/electronic_signature/locale/fr.po
+++ b/coopengo_modules/electronic_signature/locale/fr.po
@@ -200,8 +200,8 @@ msgid "The signature service is not available"
 msgstr "Le service de signature ne répond pas"
 
 msgctxt "model:ir.message,text:msg_provider_error"
-msgid "The signature service returned the following error :\n\n%(trace)s"
-msgstr "Le service de signature a renvoyé l'erreur suivante :\n\n%(trace)s"
+msgid "The signature service returned an error"
+msgstr "Le service de signature a renvoyé une erreur"
 
 msgctxt "model:ir.message,text:msg_unauthorized_transition"
 msgid ""

--- a/coopengo_modules/electronic_signature/locale/fr.po
+++ b/coopengo_modules/electronic_signature/locale/fr.po
@@ -200,8 +200,8 @@ msgid "The signature service is not available"
 msgstr "Le service de signature ne répond pas"
 
 msgctxt "model:ir.message,text:msg_provider_error"
-msgid "The signature service returned an error"
-msgstr "Le service de signature a renvoyé une erreur"
+msgid "The signature service returned an error : %(description)s"
+msgstr "Le service de signature a renvoyé une erreur : %(description)s"
 
 msgctxt "model:ir.message,text:msg_unauthorized_transition"
 msgid ""

--- a/coopengo_modules/electronic_signature/locale/fr.po
+++ b/coopengo_modules/electronic_signature/locale/fr.po
@@ -199,6 +199,10 @@ msgctxt "model:ir.message,text:msg_service_timeout"
 msgid "The signature service is not available"
 msgstr "Le service de signature ne répond pas"
 
+msgctxt "model:ir.message,text:msg_provider_error"
+msgid "The signature service returned the following error"
+msgstr "Le service de signature a renvoyé l'erreur suivante"
+
 msgctxt "model:ir.message,text:msg_unauthorized_transition"
 msgid ""
 "Could not change status to %(status)s for signature %(provider_id)s of "

--- a/coopengo_modules/electronic_signature/locale/fr.po
+++ b/coopengo_modules/electronic_signature/locale/fr.po
@@ -200,8 +200,8 @@ msgid "The signature service is not available"
 msgstr "Le service de signature ne répond pas"
 
 msgctxt "model:ir.message,text:msg_provider_error"
-msgid "The signature service returned the following error"
-msgstr "Le service de signature a renvoyé l'erreur suivante"
+msgid "The signature service returned the following error :\n\n%(trace)s"
+msgstr "Le service de signature a renvoyé l'erreur suivante :\n\n%(trace)s"
 
 msgctxt "model:ir.message,text:msg_unauthorized_transition"
 msgid ""

--- a/coopengo_modules/electronic_signature/message.xml
+++ b/coopengo_modules/electronic_signature/message.xml
@@ -11,7 +11,7 @@
             <field name="text">The signature service is not available</field>
         </record>
         <record model="ir.message" id="msg_provider_error">
-            <field name="text">The signature service returned an error</field>
+            <field name="text">The signature service returned an error : %(description)s</field>
         </record>
     </data>
 </tryton>

--- a/coopengo_modules/electronic_signature/message.xml
+++ b/coopengo_modules/electronic_signature/message.xml
@@ -11,7 +11,7 @@
             <field name="text">The signature service is not available</field>
         </record>
         <record model="ir.message" id="msg_provider_error">
-            <field name="text">The signature service returned the following error</field>
+            <field name="text">The signature service returned the following error :\n\n%(trace)s</field>
         </record>
     </data>
 </tryton>

--- a/coopengo_modules/electronic_signature/message.xml
+++ b/coopengo_modules/electronic_signature/message.xml
@@ -11,7 +11,7 @@
             <field name="text">The signature service is not available</field>
         </record>
         <record model="ir.message" id="msg_provider_error">
-            <field name="text">The signature service returned the following error :\n\n%(trace)s</field>
+            <field name="text">The signature service returned an error</field>
         </record>
     </data>
 </tryton>

--- a/coopengo_modules/electronic_signature/message.xml
+++ b/coopengo_modules/electronic_signature/message.xml
@@ -10,5 +10,8 @@
         <record model="ir.message" id="msg_service_timeout">
             <field name="text">The signature service is not available</field>
         </record>
+        <record model="ir.message" id="msg_provider_error">
+            <field name="text">The signature service returned the following error</field>
+        </record>
     </data>
 </tryton>

--- a/coopengo_modules/electronic_signature/signature.py
+++ b/coopengo_modules/electronic_signature/signature.py
@@ -9,7 +9,7 @@ from unidecode import unidecode
 from trytond import backend
 from trytond.i18n import gettext
 from trytond.config import config as config_parser
-from trytond.exceptions import TimeoutException
+from trytond.exceptions import TimeoutException, UserError
 from trytond.model import ModelSQL, ModelView, fields, Workflow
 from trytond.pyson import Eval, Not, In
 from trytond.pool import Pool
@@ -194,7 +194,7 @@ class Signature(Workflow, ModelSQL, ModelView):
             raise TimeoutException()
         if req.status_code > 299:
             prefix_msg = gettext('electronic_signature.msg_provider_error')
-            raise Exception(prefix_msg + ':' + req.content)
+            raise UserError(prefix_msg + ':\n\n' + req.content.decode('utf8'))
         response, _ = xmlrpc.client.loads(req.content.decode('utf8'))
         if conf['log']:
             signature.append_log(conf, method, data, response)

--- a/coopengo_modules/electronic_signature/signature.py
+++ b/coopengo_modules/electronic_signature/signature.py
@@ -195,7 +195,7 @@ class Signature(Workflow, ModelSQL, ModelView):
         if req.status_code > 299:
             prefix_msg = gettext('electronic_signature.msg_provider_error')
             raise UserError(prefix_msg + ':\n\n' + req.content.decode('utf8'))
-        response, _ = xmlrpc.client.loads(req.content.decode('utf8'))
+        response, _ = xmlrpc.client.loads(req.content)
         if conf['log']:
             signature.append_log(conf, method, data, response)
         return response

--- a/coopengo_modules/electronic_signature/signature.py
+++ b/coopengo_modules/electronic_signature/signature.py
@@ -196,7 +196,7 @@ class Signature(Workflow, ModelSQL, ModelView):
             raise UserError(
                 gettext('electronic_signature.msg_provider_error',
                     trace=req.content.decode('utf8')))
-        response, _ = xmlrpc.client.loads(req.content.decode('utf8'))
+        response, _ = xmlrpc.client.loads(req.content)
         if conf['log']:
             signature.append_log(conf, method, data, response)
         return response

--- a/coopengo_modules/electronic_signature/signature.py
+++ b/coopengo_modules/electronic_signature/signature.py
@@ -195,7 +195,7 @@ class Signature(Workflow, ModelSQL, ModelView):
         if req.status_code > 299:
             raise UserError(
                 gettext('electronic_signature.msg_provider_error',
-                    trace=req.content.decode('utf8')))
+                    trace=(req.text if req.text else req.status_code))
         response, _ = xmlrpc.client.loads(req.content)
         if conf['log']:
             signature.append_log(conf, method, data, response)

--- a/coopengo_modules/electronic_signature/signature.py
+++ b/coopengo_modules/electronic_signature/signature.py
@@ -193,9 +193,10 @@ class Signature(Workflow, ModelSQL, ModelView):
         except requests.Timeout:
             raise TimeoutException()
         if req.status_code > 299:
-            prefix_msg = gettext('electronic_signature.msg_provider_error')
-            raise UserError(prefix_msg + ':\n\n' + req.content.decode('utf8'))
-        response, _ = xmlrpc.client.loads(req.content)
+            raise UserError(
+                gettext('electronic_signature.msg_provider_error',
+                    trace=req.content.decode('utf8')))
+        response, _ = xmlrpc.client.loads(req.content.decode('utf8'))
         if conf['log']:
             signature.append_log(conf, method, data, response)
         return response

--- a/coopengo_modules/electronic_signature/signature.py
+++ b/coopengo_modules/electronic_signature/signature.py
@@ -195,7 +195,7 @@ class Signature(Workflow, ModelSQL, ModelView):
         if req.status_code > 299:
             prefix_msg = gettext('electronic_signature.msg_provider_error')
             raise Exception(prefix_msg + ':' + req.content)
-        response, _ = xmlrpc.client.loads(req.content)
+        response, _ = xmlrpc.client.loads(req.content.decode('utf8'))
         if conf['log']:
             signature.append_log(conf, method, data, response)
         return response

--- a/coopengo_modules/electronic_signature/signature.py
+++ b/coopengo_modules/electronic_signature/signature.py
@@ -193,7 +193,8 @@ class Signature(Workflow, ModelSQL, ModelView):
         except requests.Timeout:
             raise TimeoutException()
         if req.status_code > 299:
-            raise Exception(req.content)
+            prefix_msg = gettext('electronic_signature.msg_provider_error')
+            raise Exception(prefix_msg + ':' + req.content)
         response, _ = xmlrpc.client.loads(req.content)
         if conf['log']:
             signature.append_log(conf, method, data, response)


### PR DESCRIPTION
Fix PROCK-641

# Tests
## Récapitulatif



Description du test | Résultat attendu | Validation | Date d’exécution du test
-- | -- | -- | --
Appeler un service de signature qui renvoie une erreur | Alerte contenant un message d’erreur avec la description du statut HTTPLogs complets dans l’objet signature avec la réponse du serveurLogs du serveur Coog avec une entrée contenant ces mêmes informations | :heavy_check_mark: |  07/09/2023



## Détail des tests
### Une erreur générée par un serveur de signature est affichée et tracée :heavy_check_mark: 

* Message d'erreur :  ![image](https://github.com/coopengo/tryton/assets/56913865/f8284107-da5d-4018-885d-9f1810390105)
* Logs d'erreur de la signature (uniquement si la journalisation est activée pour ce fournisseur) : HTTP Status + contenu de la réponse serveur
![image](https://github.com/coopengo/tryton/assets/56913865/9b582d98-f05a-4780-a7c8-5f240f52a569)
*Logs Serveur Coog : HTTP Status + contenu de la réponse serveur : 
![image](https://github.com/coopengo/tryton/assets/56913865/86ae41f7-3c95-4f36-8f8d-09a7bac2f125)

Dans les 2 derniers cas, "Réponse du serveur" correspond au contenu de la réponse (response.text)


Dans les 2 derniers cas, "Réponse du serveur" correspond au contenu de la réponse (response.text)

