### PR TITLE
debug: Fix the translation of lazy_gettext strings in debug mode

### DIFF
--- a/coopengo_modules/debug/debug.py
+++ b/coopengo_modules/debug/debug.py
@@ -14,6 +14,7 @@ from trytond.model import ModelSQL, ModelView, fields
 from trytond.transaction import Transaction
 from trytond.pool import Pool
 from trytond.pyson import Eval, Bool
+from trytond.i18n import gettext
 
 logger = logging.getLogger(__name__)
 METHOD_TEMPLATES = ['default_', 'on_change_with_', 'on_change_', 'order_']
@@ -152,8 +153,10 @@ class ModelInfo(ModelView):
         ttype = 'field'
         missing_translation_src = src + ' [Missing Translation]'
         try:
-            return Translation.get_source(
-                target, ttype, language, src) or missing_translation_src
+            translation = Translation.get_source(target, ttype, language, src)
+            if not translation and src and '.msg_' in src:
+                translation = gettext(src)
+            return translation or missing_translation_src
         except ValueError:
             return missing_translation_src
 

--- a/trytond/trytond/ir/translation.py
+++ b/trytond/trytond/ir/translation.py
@@ -534,8 +534,6 @@ class Translation(ModelSQL, ModelView):
         "Return translation for source"
         args = (name, ttype, lang, source)
         result = cls.get_sources([args])
-        if not result[args] and source and source.startswith('ir.msg'):
-            result[args] = gettext(source)
         return result[args]
 
     @classmethod

--- a/trytond/trytond/ir/translation.py
+++ b/trytond/trytond/ir/translation.py
@@ -534,6 +534,8 @@ class Translation(ModelSQL, ModelView):
         "Return translation for source"
         args = (name, ttype, lang, source)
         result = cls.get_sources([args])
+        if not result[args] and source and source.startswith('ir.msg'):
+            result[args] = gettext(source)
         return result[args]
 
     @classmethod


### PR DESCRIPTION
Fix #PJAZZ-1225

![image](https://github.com/coopengo/tryton/assets/116029002/ebb95c55-5a80-40b5-a1d8-a40e1585b600)
![image](https://github.com/coopengo/tryton/assets/116029002/bbf955d5-0601-43b7-81ea-4e75cc11dd35)

