### PR TITLE
trytond: Fix translation of the translated fields message

### DIFF
--- a/trytond/trytond/ir/locale/fr.po
+++ b/trytond/trytond/ir/locale/fr.po
@@ -2680,7 +2680,7 @@ msgstr "%(field)s (nom du modèle)"
 
 msgctxt "model:ir.message,text:msg_field_string"
 msgid "%(field)s (string)"
-msgstr "%(champ)s (chaîne)"
+msgstr "%(field)s (chaîne)"
 
 msgctxt "model:ir.message,text:msg_forbidden_char_validation_record"
 msgid ""


### PR DESCRIPTION
Fix #PJAZZ-1572


![image](https://github.com/coopengo/tryton/assets/67907585/809ffdc3-074b-43b0-b723-7ba971749779)
