### PR TITLE
tryton: Fix bug when a quick_action does not have an icon [CUSTOM]

### DIFF
--- a/tryton/tryton/gui/window/form.py
+++ b/tryton/tryton/gui/window/form.py
@@ -765,9 +765,11 @@ class Form(TabContent):
         if quick_actions:
             gtktoolbar.insert(Gtk.SeparatorToolItem(), -1)
         for quick_action in quick_actions:
-            icon = quick_action.get('icon.', {}).get('rec_name')
+            icon = quick_action.get('icon.', {})
             if not icon:
                 icon = 'tryton-executable'
+            else:
+                icon = icon.get('rec_name')
 
             # prevent problem with variables scopes in lambda
             # cf. https://docs.python.org/3/faq/programming.html#


### PR DESCRIPTION
Petit bug trouvé en utilisant le mixin qui permet d'ajouter des boutons à la barre d'outils.
Si on passe une quick_action sans icon on a un crash AttributeError: 'NoneType' object has no attribute 'get' au moment du get('rec_name')