### PR TITLE
Restore always_expand support [CUSTOM]

### DIFF
--- a/sao/src/view/tree.js
+++ b/sao/src/view/tree.js
@@ -1424,6 +1424,9 @@
                     record.load(field_name, true, false).done(redraw);
                     return;
                 } else {
+                    if (row.tree.always_expand) {
+                        row.expand_row();
+                    }
                     row.redraw(selected, expanded);
                 }
             }
@@ -1830,9 +1833,6 @@
                 if (this.rows.length === 0) {
                     var children = this.record.field_get_client(
                         this.children_field);
-                    // [Coog Specific]  needed for multi_mixed_view
-                    if (children.model.name != this.record.model.name)
-                        children.model.add_fields(this.children_definitions[children.model.name]);
                     children.forEach((record, pos, group) => {
                         // The rows are added to the tbody after being rendered
                         // to minimize browser reflow

--- a/sao/src/view/tree.js
+++ b/sao/src/view/tree.js
@@ -990,7 +990,7 @@
                             expand();
                         }
                     });
-                }, 250);
+                }, 100);
                 if (this.always_expand) {
                     expand();
                 }


### PR DESCRIPTION
The call to expand_row must occur in redraw_async in order to happen on every row even the one that are never shown.

The call must happen before the redraw call as this call might itself make async calls.

PCLAS-581