### PR TITLE
Use display flex to prevent overflow of legend in the group's fieldset [CUSTOM]

### DIFF
--- a/sao/src/theme/coog/sao.less
+++ b/sao/src/theme/coog/sao.less
@@ -400,6 +400,8 @@ div.form-item.form-group_:has(> fieldset.form-group_ > legend) {
     // "legends" are special and default style is weird, transform the style to
     // look like dicts
     > fieldset.form-group_ {
+        display: flex;
+        flex-direction: column;
         box-shadow:                     @coog-box-shadow;
         margin-bottom:                  10px;
 


### PR DESCRIPTION
Fix PCLAS-709