### PR TITLE
gtk: Do not use a global variable as default for dict fields

### DIFF
--- a/tryton/tryton/gui/window/view_form/model/field.py
+++ b/tryton/tryton/gui/window/view_form/model/field.py
@@ -1169,18 +1169,15 @@ class BinaryField(Field):
 
 
 class DictField(Field):
-
-    _default = {}
-
     def __init__(self, attrs):
         super(DictField, self).__init__(attrs)
         self.keys = {}
 
     def get(self, record):
-        return super(DictField, self).get(record) or self._default
+        return super(DictField, self).get(record) or {}
 
     def get_client(self, record):
-        return super(DictField, self).get_client(record) or self._default
+        return super(DictField, self).get_client(record) or {}
 
     def validation_domains(self, record, pre_validate=None):
         screen_domain, attr_domain = self.domains_get(record, pre_validate)


### PR DESCRIPTION
Fix PCLAS-724