### PR TITLE
Revert "sao / gtk: Do not trigger an extra read for an empty rec_name [CUSTOM] (#170)"

### DIFF
--- a/sao/src/model.js
+++ b/sao/src/model.js
@@ -2232,8 +2232,8 @@
         set: function(record, value) {
             var promise;
             var rec_name = (
-                record._values[this.name + '.'] || {}).rec_name;
-            if (!rec_name && rec_name !== '' && (value >= 0) && (value !== null)) {
+                record._values[this.name + '.'] || {}).rec_name || '';
+            if (!rec_name && (value >= 0) && (value !== null)) {
                 var model_name = record.model.fields[this.name].description
                     .relation;
                 rec_name = Sao.rpc({

--- a/tryton/tryton/gui/window/view_form/model/field.py
+++ b/tryton/tryton/gui/window/view_form/model/field.py
@@ -605,8 +605,8 @@ class M2OField(Field):
             force_change=force_change)
 
     def set(self, record, value):
-        rec_name = record.value.get(self.name + '.', {}).get('rec_name')
-        if rec_name is None and value is not None and value >= 0:
+        rec_name = record.value.get(self.name + '.', {}).get('rec_name') or ''
+        if not rec_name and value is not None and value >= 0:
             try:
                 result, = RPCExecute('model', self.attrs['relation'], 'read',
                     [value], ['rec_name'])


### PR DESCRIPTION
This reverts commit ce201f1454f7604a5b8d4b3b7de842a1ec22febf.

Fix PCLAS-1116