### PR TITLE
Use absolute positioning for the expander span [CUSTOM]

### DIFF
--- a/sao/src/theme/coog/sao.less
+++ b/sao/src/theme/coog/sao.less
@@ -220,6 +220,20 @@ div.scrollbar:has(+ div.treeview) {
     border-bottom:    none;
 }
 
+// the expander in the th should be set outside of the normal flow because
+// resizing the column makes the span and the div into the th to stack
+.treeview {
+    th {
+        .expander {
+            position: absolute;
+            top: 0;
+            // A negative offset for the case so that the text inside the title
+            // does not mangle with the expander
+            left: -0.4em;
+        }
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Top Menu
 ///////////////////////////////////////////////////////////////////////////////

--- a/sao/src/theme/coog/sao.less
+++ b/sao/src/theme/coog/sao.less
@@ -229,7 +229,12 @@ div.scrollbar:has(+ div.treeview) {
             top: 0;
             // A negative offset for the case so that the text inside the title
             // does not mangle with the expander
-            left: -0.4em;
+            left: -3px;
+        }
+    }
+    th:has(> .expander) {
+        > div > label {
+            padding-left:       9px;
         }
     }
 }


### PR DESCRIPTION
Fix PCLAS-1168

This is required because the column resizing sets a width on the col and the div inside the th which make the span tag stack.

We can use absolute positioning inside the th because they're sticky and thus absolute will remove the span from the flow.