### PR TITLE
Prevent forced reflow in tree when setting column value [PREVIEW]

### DIFF
--- a/sao/src/view/tree.js
+++ b/sao/src/view/tree.js
@@ -2616,7 +2616,9 @@
                     if (!value) {
                         value = field.get_client(record) || '';
                     }
-                    cell.text(value);
+                    if (cell.text() != value) {
+                        cell.text(value);
+                    }
                 }
             };
             if (!record.is_loaded(this.attributes.name)) {
@@ -2708,7 +2710,9 @@
         },
         update_text: function(cell, record) {
             var text = this.get_textual_value(record);
-            cell.text(text).attr('title', text);
+            if (text != cell.text()) {
+                cell.text(text).attr('title', text);
+            }
         },
         render: function(record, cell) {
             if (!cell) {
@@ -2900,7 +2904,9 @@
             if (!this.tree.editable &&
                     (this.field.name + ':string' in record._values)) {
                 var text_value = this.get_textual_value(record);
-                cell.text(text_value).attr('title', text_value);
+                if (cell.text() != text_value) {
+                    cell.text(text_value).attr('title', text_value);
+                }
             } else {
                 this.update_selection(record, () => {
                     var value = this.field.get(record);
@@ -2921,7 +2927,9 @@
                         prm = jQuery.when(text);
                     }
                     prm.done(text_value => {
-                        cell.text(text_value).attr('title', text_value);
+                        if (cell.text() != text_value) {
+                            cell.text(text_value).attr('title', text_value);
+                        }
                     });
                 });
             }
@@ -2963,11 +2971,15 @@
             if (!this.tree.editable &&
                     (this.field_name + ':string' in record._values)) {
                 var text_value = this.get_textual_value(record);
-                cell.text(text_value).attr('title', text_value);
+                if (cell.text() != text_value) {
+                    cell.text(text_value).attr('title', text_value);
+                }
             } else {
                 this.update_selection(record, () => {
                     var text_value = this.get_textual_value(record);
-                    cell.text(text_value).attr('title', text_value);
+                    if (cell.text() != text_value) {
+                        cell.text(text_value).attr('title', text_value);
+                    }
                 });
             }
         },
@@ -3025,7 +3037,9 @@
             cell.unbind('click');
             this.update_selection(record, () => {
                 var text = this.get_textual_value(record);
-                cell.text(text).attr('title', text);
+                if (cell.text() != text) {
+                    cell.text(text).attr('title', text);
+                }
                 cell.click(event => {
                     event.stopPropagation();
                     var value = this.field.get(record);
@@ -3108,7 +3122,10 @@
         },
         update_text: function(cell, record) {
             var text = this.get_textual_value(record);
-            cell.children('span').text(text).attr('title', text);
+            let span = cell.children('span')
+            if (span.text() != text) {
+                span.text(text).attr('title', text);
+            }
             var button = cell.children('button');
             if (!button.length) {
                 button = jQuery('<button/>', {
@@ -3244,8 +3261,10 @@
             var value = this.field.get(record) || 0;
             var progressbar = cell.find('.progress-bar');
             progressbar.attr('aria-valuenow', value * 100);
-            progressbar.css('width', value * 100 + '%');
-            progressbar.text(text).attr('title', text);
+            if (progressbar.text() != text) {
+                progressbar.css('width', value * 100 + '%');
+                progressbar.text(text).attr('title', text);
+            }
         }
     });
 


### PR DESCRIPTION
jQuery's .text() does an .empty() call unconditionally which result in the browser thinking the DOM has changed even when the textual is identical

Fix PCLAS-1502