### PR TITLE
Reset completely the overflow for modal-body

### DIFF
--- a/sao/src/common.js
+++ b/sao/src/common.js
@@ -3687,7 +3687,7 @@
         el.closest('.treeview')
             .css('overflow-y', overflow)
             .css('max-height', height);
-        el.closest('.modal-body').css('overflow-y', overflow);
+        el.closest('.modal-body').css('overflow', overflow);
         el.closest('.navbar-collapse.in').css('overflow-y', overflow);
         el.closest('.content-box').css('overflow-y', overflow);
         el.parents('fieldset.form-group_').css('overflow', overflow);


### PR DESCRIPTION
This one is a complicated beast:

    - having defined an `overflow-x: auto` in CSS on modal-body make it a new Block Formatting Context
    - Block Formatting Context contains their floating elements
    - This is why although the ul menu is in the same stacking context than the modal footer, the menu does not appear above it.
    - Thus setting the `overflow` property will also reset the `overflow-x` property and since the value is `visible` it does not create a new Block Formatting Context, ensuring the `z-index` take effect.

Fix PCLAS-1506