### PR TITLE
tryton: Allow brackets in file name when exporting an object [CUSTOM]

### DIFF
--- a/tryton/tryton/common/common.py
+++ b/tryton/tryton/common/common.py
@@ -530,14 +530,12 @@ def slugify(value):
     return _slugify_hyphenate_re.sub('-', value)
 
 
-_slugify_brace_strip_re = re.compile(r'[^\w\s\-\[\]]')
-
-
-def slugify_file_name(value):
+def _slugify_sub_filename(value):
+    _slugify_braket_strip_re = re.compile(r'[^\w\s\-\[\]]')
     if not isinstance(value, str):
         value = str(value)
     value = unicodedata.normalize('NFKD', value)
-    value = str(_slugify_brace_strip_re.sub('', value).strip())
+    value = str(_slugify_braket_strip_re.sub('', value).strip())
     return _slugify_hyphenate_re.sub('-', value)
 
 
@@ -546,7 +544,7 @@ def _slugify_filename(filename):
         name, ext = filename
     else:
         name, ext = os.path.splitext(filename)
-    return ''.join([slugify_file_name(name), os.extsep, slugify(ext)])
+    return ''.join([_slugify_sub_filename(name), os.extsep, slugify(ext)])
 
 
 def file_write(filename, data):

--- a/tryton/tryton/common/common.py
+++ b/tryton/tryton/common/common.py
@@ -530,12 +530,23 @@ def slugify(value):
     return _slugify_hyphenate_re.sub('-', value)
 
 
+_slugify_brace_strip_re = re.compile(r'[^\w\s\-\[\]]')
+
+
+def slugify_file_name(value):
+    if not isinstance(value, str):
+        value = str(value)
+    value = unicodedata.normalize('NFKD', value)
+    value = str(_slugify_brace_strip_re.sub('', value).strip())
+    return _slugify_hyphenate_re.sub('-', value)
+
+
 def _slugify_filename(filename):
     if not isinstance(filename, str):
         name, ext = filename
     else:
         name, ext = os.path.splitext(filename)
-    return ''.join([slugify(name), os.extsep, slugify(ext)])
+    return ''.join([slugify_file_name(name), os.extsep, slugify(ext)])
 
 
 def file_write(filename, data):


### PR DESCRIPTION
Fix #PROCK-3283

Before :
file name : 2025-01-17partyparty379181.json
After : 
![image](https://github.com/user-attachments/assets/a0106784-5fd0-43ec-9f02-d5f17206b914)

Fonctionne déjà sur SAO : 
![image](https://github.com/user-attachments/assets/cd100842-1718-49e7-af01-7f5e127e8baf)

Viens probablement de ce [commit](https://github.com/coopengo/tryton/commit/6b1a4a9f274809013121c24eb64f519b1b3be2da?diff=split ) mais l'explication de pourquoi n'est vraiment pas évidante

Backtrack : 
24.14, 24.41