### PR TITLE
Use the initial precision when applying factor to a field without digits

### DIFF
--- a/sao/src/model.js
+++ b/sao/src/model.js
@@ -2147,12 +2147,23 @@
         },
         apply_factor: function(record, value, factor) {
             if (value !== null) {
+                let initial_precision = (value.toString().split('.')[1] || '').length;
+                initial_precision += Math.ceil(Math.log10(factor));
                 value /= factor;
                 var digits = this.digits(record);
                 if (digits) {
                     // Round to avoid float precision error
                     // after the division by factor
                     value = value.toFixed(digits[1]);
+                } else {
+                    // The intial precision is the one used by value (before
+                    // applying the factor), per the ecmascript specification
+                    // it's the shortest representation of said value.
+                    // Once the factor is applied the number might become even
+                    // more inexact thus we should rely on the initial
+                    // precision + the effect factor will have
+                    // https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-numeric-types-number-tostring
+                    value = value.toFixed(initial_precision);
                 }
                 value = this.convert(value);
             }

--- a/tryton/tryton/gui/window/view_form/model/field.py
+++ b/tryton/tryton/gui/window/view_form/model/field.py
@@ -493,10 +493,20 @@ class FloatField(Field):
 
     def apply_factor(self, record, value, factor):
         if value is not None:
+            initial_precision = len((str(value).split('.', 2) + [''])[1])
+            initial_precision += math.ceil(math.log10(factor))
             value /= factor
             digits = self.digits(record)
             if digits:
                 value = round(value, digits[1])
+            else:
+                # The intial precision is the one used by value (before
+                # applying the factor), per the ecmascript specification
+                # it's the shortest representation of said value.
+                # Once the factor is applied the number might become even
+                # more inexact thus we should rely on the initial
+                # precision + the effect factor will have
+                value = round(value, initial_precision)
             value = self.convert(value)
         return value
 


### PR DESCRIPTION
Without digits the full representation of the number is used which might not be the expected behaviour because applying the factor will result in a number which short representation could be surprising to the user.

Fix PCLAS-1656
https://bugs.tryton.org/10460