### PR TITLE
trytond: Remove duplicate header in export routes [PREVIEW]

### DIFF
--- a/trytond/trytond/ir/routes.py
+++ b/trytond/trytond/ir/routes.py
@@ -269,7 +269,6 @@ def data(request, pool, model):
         response = Response(data, mimetype='text/csv; charset=' + encoding)
         response.headers.add(
             'Content-Disposition', 'attachment', filename=filename)
-        response.headers.add('Content-Length', len(data))
         return response
 
 


### PR DESCRIPTION
Latest versions of Nginx refuses responses with duplicate headers. The export route manually adds the `Content-Length` header, but the Wsgi server will also add it automatically.

Issue link: [https://coopengo.atlassian.net/browse/PCLAS-1667](https://coopengo.atlassian.net/browse/PCLAS-1667)

Fix PCLAS-1667