### PR TITLE
sao: Set current screen context in import / export popup [CUSTOM]

### DIFF
--- a/sao/src/window.js
+++ b/sao/src/window.js
@@ -1396,7 +1396,8 @@
         },
         _get_fields: function(model) {
             return Sao.rpc({
-                'method': 'model.' + model + '.fields_get'
+                'method': 'model.' + model + '.fields_get',
+                'params': [this.screen.context],
             }, this.session, false);
         },
         on_row_expanded: function(node) {
@@ -1719,7 +1720,7 @@
                     Sao.rpc({
                         'method': 'model.' + this.screen.model_name +
                         '.import_data',
-                        'params': [fields, data, {}]
+                        'params': [fields, data, this.screen.context]
                     }, this.session).then(count => {
                         return Sao.common.message.run(
                             Sao.i18n.ngettext('%1 record imported',


### PR DESCRIPTION
In some cases, there may be field names / filters that depend on the
context of the view. This change is consistent with the current behaviour
of the GTK client.

Issue link: [https://coopengo.atlassian.net/browse/PCLAS-1758](https://coopengo.atlassian.net/browse/PCLAS-1758)

Fix PCLAS-1758