### PR TITLE
[merge 7.6] trytond: Wrong behaviour of rules with dots [PREVIEW]

### DIFF
--- a/trytond/trytond/ir/rule.py
+++ b/trytond/trytond/ir/rule.py
@@ -279,8 +279,18 @@ class Rule(ModelSQL, ModelView):
             target_model = rule.rule_group.model
             if target_model in model2field:
                 target_dom = ['OR']
+                fields_to_check = set()
                 for field in model2field[target_model]:
+                    if field not in fields_to_check:
+                        cur_path = None
+                        for part in field.split('.'):
+                            cur_path = (
+                                part if cur_path is None
+                                else f'{cur_path}.{part}')
+                            fields_to_check.add(cur_path)
                     target_dom.append((field, 'where', dom))
+                for path in fields_to_check:
+                    target_dom.append((path, '=', None))
                 dom = target_dom
             if rule.rule_group.global_p:
                 clause_global[rule.rule_group].append(dom)


### PR DESCRIPTION
Before version 7.6, [('address.party', '=', None)] would match a record with an empty "address" field, but it is no longer the case.

This causes some regressions with ir.rules.

Example:

- On party.address, have a rule with
```
    [('party.portfolio_allowed', '=', True])
```
- When creating a party.identifier, __check_domain_rule will try to validate the "address" field, applying this rule

- Now, create a new party identifier without setting its address field

In version 7.6, the rule will fail because the effective domain will be

    [('address.party', 'where', [['portfolio_allowed', '=', True]]])

which will not match a record where the "address" field is empty. In version 7.2, this rule would actually match.

(The actual generated domain in the use case is slightly more complex, but the general idea is the same:
```
[['OR', ['OR', ('address.party', 'where', [['portfolio_allowed', '=', True]])]],
 ['OR', ['OR', ('address', 'where', [['portfolio_allowed', '=', True]])]]]
```
Issue link: [https://coopengo.atlassian.net/browse/PCLAS-1838](https://coopengo.atlassian.net/browse/PCLAS-1838)

Fix PCLAS-1838