### PR TITLE
trytond: Add autocomplete API for sao 7.2 compatibility [CUSTOM]

### DIFF
--- a/trytond/CHANGELOG
+++ b/trytond/CHANGELOG
@@ -1,4 +1,5 @@
 * Use JSONB to store MultiSelection field on PostgreSQL
+* Add autocomplete method on ModelView
 * Use multiple jobs to dump and restore a test database
 * Support database cache as template for tests
 


### PR DESCRIPTION
Un-knoting the changes in Sao to avoid calling "autocomplete" was definitely
harder than adding the matching API server-side.

Issue link: [https://coopengo.atlassian.net/browse/PCLAS-1854](https://coopengo.atlassian.net/browse/PCLAS-1854)

Fix PCLAS-1854