### PR TITLE
Set exclude_field on group when creating a default one [PREVIEW]

### DIFF
--- a/sao/src/model.js
+++ b/sao/src/model.js
@@ -2700,6 +2700,7 @@
             var group = Sao.Group(model, {}, []);
             group.set_parent(record);
             group.parent_name = this.description.relation_field;
+            group.exclude_field = this.description.relation_field;
             group.child_name = this.name;
             group.parent_datetime_field = this.description.datetime_field;
             record._values[this.name] = group;

--- a/sao/src/model.js
+++ b/sao/src/model.js
@@ -1357,6 +1357,9 @@
                 if (fname == this.group.exclude_field) {
                     continue;
                 }
+                if (fname == this.group.parent_name) {
+                    continue;
+                }
                 if (!field.validate(this, softvalidation, pre_validate)) {
                     result = false;
                 }
@@ -2700,7 +2703,6 @@
             var group = Sao.Group(model, {}, []);
             group.set_parent(record);
             group.parent_name = this.description.relation_field;
-            group.exclude_field = this.description.relation_field;
             group.child_name = this.name;
             group.parent_datetime_field = this.description.datetime_field;
             record._values[this.name] = group;

--- a/tryton/tryton/gui/window/view_form/model/field.py
+++ b/tryton/tryton/gui/window/view_form/model/field.py
@@ -682,6 +682,7 @@ class O2MField(Field):
                 parent_name=parent_name,
                 child_name=self.name,
                 parent_datetime_field=self.attrs.get('datetime_field'))
+        group.exclude_field = parent_name
         if not fields and record.model_name == self.attrs['relation']:
             group.fields = record.group.fields
         record.value[self.name] = group

--- a/tryton/tryton/gui/window/view_form/model/field.py
+++ b/tryton/tryton/gui/window/view_form/model/field.py
@@ -682,7 +682,6 @@ class O2MField(Field):
                 parent_name=parent_name,
                 child_name=self.name,
                 parent_datetime_field=self.attrs.get('datetime_field'))
-        group.exclude_field = parent_name
         if not fields and record.model_name == self.attrs['relation']:
             group.fields = record.group.fields
         record.value[self.name] = group

--- a/tryton/tryton/gui/window/view_form/model/record.py
+++ b/tryton/tryton/gui/window/view_form/model/record.py
@@ -476,6 +476,8 @@ class Record:
                 continue
             if field_name == self.group.exclude_field:
                 continue
+            if field_name == self.group.parent_name:
+                continue
             if not field.validate(self, softvalidation, pre_validate):
                 res = False
         return res


### PR DESCRIPTION
This is required because when an on_change sets a x2M fields without a screen the exclude_field will be null. Thus the client will try to validate the new children record and thus the parent field but it shouldn't.

Fix PCLAS-1875