### PR TITLE
Set default value of src_plural to NULL when setting translations [PREVIEW]

### DIFF
--- a/trytond/trytond/ir/translation.py
+++ b/trytond/trytond/ir/translation.py
@@ -1292,7 +1292,7 @@ class TranslationSet(Wizard):
                         [
                             [view.model, INTERNAL_LANG,
                                 'view', string,
-                                '', '',
+                                Null, '',
                                 '', '',
                                 '', view.module,
                                 False, Null]]))


### PR DESCRIPTION
Adding the new translations to the internal language should set the value of src_plural to NULL as this is the default value we use when importing from the PO files. Moreover it might happen that an empty string could be a valid value for src_plural.

https://bugs.tryton.org/14289
https://coopengo.atlassian.net/browse/PCLAS-1827