### PR TITLE
Set width to 100% on all elements between pane and screen-container [PREVIEW]

### DIFF
--- a/sao/src/sao.less
+++ b/sao/src/sao.less
@@ -288,27 +288,32 @@ html[theme="default"] {
     width: 100%;
     overflow-x: auto;
 
-    > .tab-pane > .panel {
-        display: flex;
-        flex-direction: column;
-        flex: 1;
-        margin-bottom: 5px;
-        padding-bottom: 0;
-        max-width: 100%;
+    > .tab-pane {
+        width: 100%;
 
-        > .panel-body {
+        > .panel {
             display: flex;
+            flex-direction: column;
             flex: 1;
-            flex-direction: row;
-            padding: 0;
-            min-height: 0;
-            overflow-y: auto;
+            margin-bottom: 5px;
+            padding-bottom: 0;
+            width: 100%;
 
-            > div {
-                display: inline-flex;
+            > .panel-body {
+                display: flex;
+                flex: 1;
+                flex-direction: row;
+                padding: 5px 0;
+                min-height: 0;
+                width: 100%;
 
-                &:first-child {
-                    flex: 2;
+                > div {
+                    display: inline-flex;
+                    width: 100%;
+
+                    &:first-child {
+                        flex: 2;
+                    }
                 }
             }
         }
@@ -715,6 +720,7 @@ img.icon {
     display: flex;
     flex-direction: column;
     flex: 1;
+    width: 100%;
 }
 
 .filter-box {


### PR DESCRIPTION
Without the 100% width, Chrome does not render an horizontal scrollbar when the form overflow the pane width.

https://bugs.tryton.org/14197
https://coopengo.atlassian.net/browse/PCLAS-1887