### PR TITLE
trytond: Add extra check before inserting history

### DIFF
--- a/trytond/trytond/model/modelsql.py
+++ b/trytond/trytond/model/modelsql.py
@@ -720,7 +720,8 @@ class ModelSQL(ModelStorage):
     def _insert_history(cls, ids, deleted=False):
         transaction = Transaction()
         cursor = transaction.connection.cursor()
-        if not cls._history:
+        if not cls._history or not backend.TableHandler.table_exist(
+                cls._table + "__history"):
             return
         user = transaction.user
         table = cls.__table__()


### PR DESCRIPTION
Fix #00000

When we go through `Translation.delete_deprecated_translation` which is called before `super().__register__`: we try to delete translations (which triggers history insertion),
but the history table may not exist yet when we are upgrading from a version below 25.14

https://github.com/coopengo/coog/commit/a0bb37b3132f