### PR TITLE
ui: Fix crash regarding new attribute 'mode' on graphs after 947c2b

### DIFF
--- a/trytond/trytond/ir/ui/graph.rng
+++ b/trytond/trytond/ir/ui/graph.rng
@@ -53,6 +53,17 @@
       </attribute>
     </optional>
   </define>
+  <define name="attlist.graph" combine="interleave">
+    <optional>
+      <attribute a:defaultValue="percentage">
+        <name ns="">mode</name>
+        <choice>
+          <value>percentage</value>
+          <value>number</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
   <define name="x">
     <element>
       <name ns="">x</name>


### PR DESCRIPTION
Fix #00000

(after : https://github.com/coopengo/coog/pull/13260)