### PR TITLE
model: Hide `xml_id` field on models' undefined form views

### DIFF
--- a/trytond/trytond/model/modelview.py
+++ b/trytond/trytond/model/modelview.py
@@ -308,8 +308,8 @@ class ModelView(Model):
                 xml = '''<?xml version="1.0"?>''' \
                     '''<form col="4">'''
                 for i in res:
-                    if i in ('create_uid', 'create_date',
-                            'write_uid', 'write_date', 'id', 'rec_name'):
+                    if i in ('create_uid', 'create_date', 'write_uid',
+                             'write_date', 'id', 'rec_name', 'xml_id'):
                         continue
                     if res[i]['type'] not in ('one2many', 'many2many'):
                         xml += '<label name="%s"/>' % (i,)


### PR DESCRIPTION
Fix #PJAZZ-4008

[PJAZZ-4008](https://coopengo.atlassian.net/browse/PJAZZ-4008)

### Screenshots :

#### Before :
<img width="1024" height="73" alt="image" src="https://github.com/user-attachments/assets/b8985672-348c-4eef-a4b8-a99a555db8f6" />

#### After :
<img width="1488" height="125" alt="image" src="https://github.com/user-attachments/assets/e00b83ec-2769-4b06-9a6c-253dea3c2149" />

[PJAZZ-4008]: https://coopengo.atlassian.net/browse/PJAZZ-4008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ