### PR TITLE
sao: Fix search dropdown open state

### DIFF
--- a/sao/src/common.js
+++ b/sao/src/common.js
@@ -4014,7 +4014,7 @@
             });
         },
         _show: function() {
-            if (this.dropdown.hasClass('open')) {
+            if (!this.dropdown.hasClass('open')) {
                 this.menu.dropdown('toggle');
             }
             this.menu.css('display', 'block');


### PR DESCRIPTION
Fix #PMETA-3428

https://coopengo.atlassian.net/browse/PMETA-3428

The "open" state was seemingly never initialized since [PCLAS-2046](https://coopengo.atlassian.net/browse/PCLAS-2046),
which messed with the event handler logic on the down key to focus results.

[PCLAS-2046]: https://coopengo.atlassian.net/browse/PCLAS-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ