### PR TITLE
sao: Allow displaying the gross value instead of percentages in pie billboards with the 'pie_mode' attribute

### DIFF
--- a/sao/src/view/coog.js
+++ b/sao/src/view/coog.js
@@ -61,6 +61,24 @@
             this._x_sao = structuredClone(value['x-sao']);
             if (['pie', 'donut'].includes(value.data.type)) {
                 this._remap_ids();
+                if (this.attributes.pie_mode && (this.attributes.pie_mode == 'number')) {
+                    Object.assign(value, {
+                        pie: {
+                            label: {
+                                format: function (value, ratio, id) {
+                                    return value;
+                                }
+                            }
+                        },
+                        tooltip: {
+                            format: {
+                                value: function (value, ratio, id) {
+                                    return value;
+                                }
+                            }
+                        },
+                    });
+                };
             }
             Object.assign(value, {
                 bindto: `#${this.el.attr('id')}`,

--- a/trytond/trytond/ir/ui/form.rng
+++ b/trytond/trytond/ir/ui/form.rng
@@ -253,6 +253,7 @@
           <value>time</value>
           <value>timedelta</value>
           <value>url</value>
+          <value>billboard</value>
         </choice>
       </attribute>
     </optional>
@@ -585,6 +586,17 @@
         <choice>
           <value>0</value>
           <value>1</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="attlist.field" combine="interleave">
+    <optional>
+      <attribute a:defaultValue="percentage">
+        <name ns="">pie_mode</name>
+        <choice>
+          <value>percentage</value>
+          <value>number</value>
         </choice>
       </attribute>
     </optional>


### PR DESCRIPTION
Fix #PJAZZ-3960

[PJAZZ-3960](https://coopengo.atlassian.net/browse/PJAZZ-3960)

(needed for : https://github.com/coopengo/coog/pull/13881)

[PJAZZ-3960]: https://coopengo.atlassian.net/browse/PJAZZ-3960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ