### PR TITLE
ir: Add 'deprecated' tag on modules' config to mark them as deprecated

### DIFF
--- a/trytond/trytond/ir/locale/fr.po
+++ b/trytond/trytond/ir/locale/fr.po
@@ -3035,6 +3035,10 @@ msgctxt "model:ir.message,text:msg_chat_follower_channel_email_unique"
 msgid "An email can follow a channel only once."
 msgstr "Une adresse électronique ne peut suivre un canal qu'une seule fois."
 
+msgctxt "model:ir.message,text:msg_module_deprecated"
+msgid "Module %(module)s is deprecated. Neither this module nor the modules that depend on it can be installed"
+msgstr "Le module %(module)s est obsolète. Ni ce module, ni les modules qui en dépendent ne peuvent être installés"
+
 msgctxt "model:ir.message,text:msg_chat_follower_channel_user_unique"
 msgid "A user can follow a channel only once."
 msgstr "Un utilisateur ne peut suivre un canal qu'une seule fois."

--- a/trytond/trytond/ir/message.xml
+++ b/trytond/trytond/ir/message.xml
@@ -511,5 +511,8 @@ this repository contains the full copyright notices and license terms. -->
         <record model="ir.message" id="msg_chat_author_email_invalid">
             <field name="text">The email address "%(email)s" is not valid.</field>
         </record>
+        <record model="ir.message" id="msg_module_deprecated">
+            <field name="text">Module %(module)s is deprecated, neither this module nor the modules that depend on it can be installed</field>
+        </record>
     </data>
 </tryton>

--- a/trytond/trytond/ir/module.py
+++ b/trytond/trytond/ir/module.py
@@ -9,7 +9,7 @@ from trytond.exceptions import UserError
 from trytond.i18n import gettext
 from trytond.model import ModelSQL, ModelView, Unique, fields, sequence_ordered
 from trytond.model.exceptions import AccessError
-from trytond.modules import get_module_info, get_modules
+from trytond.modules import get_module_info, get_modules, is_module_deprecated
 from trytond.pool import Pool
 from trytond.pyson import Eval, If
 from trytond.rpc import RPC
@@ -164,7 +164,16 @@ class Module(ModelSQL, ModelView):
             return parents
 
         for module in modules:
-            modules_activated.update((m for m in get_parents(module)
+            parents = get_parents(module)
+            deprecated = is_module_deprecated([module.name] + [x.name for x in parents])
+            if deprecated:
+                raise UserError(
+                    gettext(
+                        'ir.msg_module_deprecated',
+                        module=deprecated
+                    )
+                )
+            modules_activated.update((m for m in parents
                     if m.state == 'not activated'))
         cls.write(list(modules_activated), {
                 'state': 'to activate',

--- a/trytond/trytond/modules/__init__.py
+++ b/trytond/trytond/modules/__init__.py
@@ -195,6 +195,22 @@ def is_module_to_install(module, update):
     return False
 
 
+def get_parents(module):
+    info = get_module_info(module)
+    parents = set(info.get("depends", []))
+    for module in info.get("depends", []):
+        parents.update(get_parents(module))
+    return parents
+
+
+def is_module_deprecated(modules):
+    for module in modules:
+        info = get_module_info(module)
+        if info.get("deprecated", "").lower() == "true":
+            return module
+    return None
+
+
 def load_translations(pool, node, languages, prefix):
     module = node.name
     localedir = '%s/%s' % (node.info['directory'], 'locale')
@@ -308,6 +324,16 @@ def load_module_graph(graph, pool, update=None, lang=None, indexes=None):
                     if package_state == 'activated':
                         package_state = 'to upgrade'
                     elif package_state != 'to remove':
+                        deprecated = is_module_deprecated(
+                            [module] + list(get_parents(module))
+                        )
+                        if deprecated:
+                            logger.warning(
+                                'Module "%s" is deprecated, neither this module nor the'
+                                ' modules that depend on it can be installed',
+                                deprecated
+                            )
+                            continue
                         package_state = 'to activate'
                 for child in node:
                     module2state[child.name] = package_state


### PR DESCRIPTION
Fix #PJAZZ-4194

[PJAZZ-4194](https://coopengo.atlassian.net/browse/PJAZZ-4194)

Screenshots :
========
### file /module/contract_set/tryton.cfg :
<img width="307" height="403" alt="image" src="https://github.com/user-attachments/assets/7a083172-ad24-4cb3-b619-056d4ad28987" />

### Result when trying to install it for the first time :
<img width="604" height="227" alt="image" src="https://github.com/user-attachments/assets/547b308e-f1f7-4176-b2a9-361dd98ccc1c" />

<img width="1848" height="212" alt="image" src="https://github.com/user-attachments/assets/29dead45-577f-4e58-afce-13d61174c799" />

[PJAZZ-4194]: https://coopengo.atlassian.net/browse/PJAZZ-4194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ