### PR TITLE
sao: rework checkbox style

### DIFF
--- a/sao/src/theme/coog/sao.less
+++ b/sao/src/theme/coog/sao.less
@@ -215,7 +215,7 @@ div.wizard-form {
 // More discrete checkboxes for selection in trees
 .treeview > table.tree,table.tree-condensed > thead,tbody > tr > td.selection-state > input {
     & :after {
-        border-color:   @color-lightest-blue !important;
+        border-color:   @color-lighter-blue !important;
     }
 
     & tr:hover :after {
@@ -228,6 +228,11 @@ div.wizard-form {
 
     & tr.selected :after {
         border-color:   @color-grey !important;
+    }
+
+    & input[disabled]::after  {
+        border-color:   @color-lightest-blue !important;
+        cursor: not-allowed !important;
     }
 
 }


### PR DESCRIPTION
Fix #PROCK-6889

[Issue Link](https://coopengo.atlassian.net/browse/PROCK-6889)

## Screenshots : 
### Avant:
<img width="353" height="218" alt="image" src="https://github.com/user-attachments/assets/1269187f-f195-4615-9691-54af2d286673" />

### Après:
<img width="357" height="220" alt="image" src="https://github.com/user-attachments/assets/82f05884-d8de-4e9e-b62a-33cdcb77dff8" />

Ajout du curseur _not allowed_ sur les checkbox readonly
<img width="1195" height="292" alt="image" src="https://github.com/user-attachments/assets/b2c810d1-1561-4792-9361-143c357d2022" />

